### PR TITLE
Test parameters forwarded to cargo test

### DIFF
--- a/stackable-scripts/test-agent.sh
+++ b/stackable-scripts/test-agent.sh
@@ -8,5 +8,5 @@ cd /agent-integration-tests
 
 # --test-treads=1 is required to prevent the suite from failing on the first run.
 # This is due to a bug in k3s.
-cargo test --target-dir /build/agent-integration-tests -- --nocapture --test-threads=1
+cargo test --target-dir /build/agent-integration-tests -- --nocapture --test-threads=1 $@
 


### PR DESCRIPTION
This change allows to select test cases instead of running all of them.

```
$ ./run.sh debian /root/test-agent.sh logs
    Finished test [unoptimized + debuginfo] target(s) in 0.07s
     Running tests/logs.rs (/build/agent-integration-tests/debug/deps/logs-85decd6e2c55cb89)

running 2 tests
test all_logs_should_be_retrievable ... ok
test the_tail_of_logs_should_be_retrievable ... ok

test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 1 filtered out; finished in 22.87s

     Running tests/node.rs (/build/agent-integration-tests/debug/deps/node-917cbdf1118ed758)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s

     Running tests/service.rs (/build/agent-integration-tests/debug/deps/service-600e91355f586a35)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.00s
```