### PR TITLE
Fix multiple annoyances discovered after serveral attempts to test the zookeeper-operator.

### DIFF
--- a/clean.sh
+++ b/clean.sh
@@ -2,10 +2,18 @@
 
 CONTAINER_OS_NAME=${1:-debian}
 
-COMPOSE_DIR="debian"
-if [ "${CONTAINER_OS_NAME}" != "debian" ]; then
-  COMPOSE_DIR=centos
-fi
+case "${CONTAINER_OS_NAME}" in
+  debian)
+    COMPOSE_DIR="debian"
+  ;;
+  centos*)
+    COMPOSE_DIR="centos"
+  ;;
+  *)
+    >&2 echo Invalid container os name: ${CONTAINER_OS_NAME}
+    exit 1
+  ;;
+esac
 
 docker-compose -f ${COMPOSE_DIR}/docker-compose.yml --env-file=.env down --volumes
 

--- a/stackable-scripts/apply-cr-repository.sh
+++ b/stackable-scripts/apply-cr-repository.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+kubectl apply -f /stackable-scripts/cr/repository.yaml
+

--- a/stackable-scripts/cr/repository.yaml
+++ b/stackable-scripts/cr/repository.yaml
@@ -1,0 +1,9 @@
+apiVersion: "stable.stackable.de/v1"
+kind: Repository
+metadata:
+  name: stackablerepo
+spec:
+  repo_type: StackableRepo
+  properties:
+    url: https://repo.stackable.tech/repository/packages/
+

--- a/stackable-scripts/install-agent.sh
+++ b/stackable-scripts/install-agent.sh
@@ -42,12 +42,20 @@ Environment="KUBECONFIG=/etc/rancher/k3s/k3s.yaml"
 EOF
 }
 
+wait_for_k3s() {
+  until kubectl get crds; do
+    >&2 echo "k3s is not running yet."
+    sleep 1
+  done
+}
+
 #--------------------
 # main
 #--------------------
 {
   install_agent_package
   install_service_environment
+  wait_for_k3s
 /stackable-scripts/apply-spec-repository.sh
 /stackable-scripts/apply-cr-repository.sh
 nohup /stackable-scripts/approve-cert-request.sh &

--- a/stackable-scripts/install-agent.sh
+++ b/stackable-scripts/install-agent.sh
@@ -14,12 +14,14 @@ install_agent_package() {
     debian)
       apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 16dd12f5c7a6d76a
       echo deb https://repo.stackable.tech/repository/deb-release buster main | tee  /etc/apt/sources.list.d/stackable.list
-      apt-get update && apt-get install -y stackable-agent
+      apt-get update -o Dir::Etc::sourcelist="sources.list.d/stackable.list" -o Dir::Etc::sourceparts="-" -o APT::Get::List-Cleanup="0"
+      apt-get install -y stackable-agent
       ;;
     centos)
       # TODO: maybe add the gpg key here too
       yum-config-manager --add-repo=https://repo.stackable.tech/repository/rpm-release/el${VERSION}/
-      yum update && yum install -y stackable-agent --nogpgcheck
+      yum --disablerepo="*" --enablerepo="repo.stackable.*" update
+      yum install -y stackable-agent --nogpgcheck
       ;;
     *)
       echo [ERROR] Don\'t know how to install the stackable agent on this system.

--- a/stackable-scripts/install-agent.sh
+++ b/stackable-scripts/install-agent.sh
@@ -48,7 +48,8 @@ EOF
 {
   install_agent_package
   install_service_environment
-nohup /stackable-scripts/apply-spec-repository.sh &
+/stackable-scripts/apply-spec-repository.sh
+/stackable-scripts/apply-cr-repository.sh
 nohup /stackable-scripts/approve-cert-request.sh &
   systemctl start stackable-agent
 }

--- a/stackable-scripts/run-agent.sh
+++ b/stackable-scripts/run-agent.sh
@@ -8,9 +8,9 @@ set -e
 
 source ${HOME}/.cargo/env
 
-nohup /stackable-scripts/apply-spec-repository.sh
+nohup /stackable-scripts/apply-spec-repository.sh &
 
-nohup /stackable-scripts/approve-cert-request.sh
+nohup /stackable-scripts/approve-cert-request.sh &
 
 export RUST_LOG=info,stackable_agent=trace
 

--- a/stackable-scripts/run-operator.sh
+++ b/stackable-scripts/run-operator.sh
@@ -13,11 +13,5 @@ COMPONENT=$(pwd | sed 's/^\///')
 
 OPERATOR_BIN_NAME=stackable-$COMPONENT-server
 
-# kill the operator if it's already running
-OPERATOR_PID=$(ps -u | grep ${OPERATOR_BIN_NAME} | grep -v grep | awk '{print $2}')
-if [ "${OPERATOR_PID}" != "" ]; then
-  kill -term ${OPERATOR_PID}
-fi
-
 cargo run --verbose --target-dir /build/operator --bin ${OPERATOR_BIN_NAME}
 

--- a/stackable-scripts/test-agent.sh
+++ b/stackable-scripts/test-agent.sh
@@ -10,3 +10,11 @@ cd /agent-integration-tests
 # This is due to a bug in k3s.
 cargo test --target-dir /build/agent-integration-tests -- --nocapture --test-threads=1 $@
 
+# kill the agent to prepare for possible code changes
+AGENT_BIN_NAME=stackable-agent
+AGENT_PID=$(ps -u | grep ${AGENT_BIN_NAME} | grep -v grep | awk '{print $2}')
+if [ "${AGENT_PID}" != "" ]; then
+  kill -term ${AGENT_PID}
+fi
+
+

--- a/stackable-scripts/test-operator.sh
+++ b/stackable-scripts/test-operator.sh
@@ -11,3 +11,11 @@ cd /${COMPONENT}-integration-tests
 # --test-treads=1 is required to prevent the suite from failing on the first run.
 cargo test --target-dir /build/${COMPONENT}-integration-tests -- --nocapture --test-threads=1 $@
 
+# kill the operator to prepare for possible code changes.
+OPERATOR_BIN_NAME=stackable-$COMPONENT-server
+OPERATOR_PID=$(ps -u | grep ${OPERATOR_BIN_NAME} | grep -v grep | awk '{print $2}')
+if [ "${OPERATOR_PID}" != "" ]; then
+  kill -term ${OPERATOR_PID}
+fi
+
+


### PR DESCRIPTION
This PR fixes multiple annoyances and/or bugs discovered when working with the zookeeper-operator:

* clean.sh validates it's argument to avoid leaving the cluster in a dangling state.
* stop the agent/operator when the corresponding integration tests finish.
* wait for k3s to be really up und and running before creating custom resources.'
* create the stackable repo CR when installing the agent.
* Only update the stackable repo when installing the agent.

