### PR TITLE
Remove script command before passing args to cargo test

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env sh
 
 COMMAND=${1}
+shift;
 
 agent_container_name() {
   docker ps | awk '/agent/ {print $NF}'


### PR DESCRIPTION
As the title says, this was an oversight.