### PR TITLE
Label agents/kubelets with node=<num>

### DIFF
--- a/stackable-scripts/functions.sh
+++ b/stackable-scripts/functions.sh
@@ -14,4 +14,3 @@ fatal()
     exit 1
 }
 
-


### PR DESCRIPTION
Label agents/kubelets with node=<num> where num is the corresponding container number.

This is done to assist tests in reusing nodes.