### PR TITLE
Use the rust stable toolchain instead of nightly

### DIFF
--- a/centos/Dockerfile
+++ b/centos/Dockerfile
@@ -40,8 +40,8 @@ WORKDIR /root
 
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
  && . $HOME/.cargo/env \
- && rustup toolchain install nightly \
- && rustup default nightly
+ && rustup toolchain install stable \
+ && rustup default stable
 
 
 #------------------------------------------------------------------------------

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -68,8 +68,8 @@ RUN rm -f /lib/systemd/system/multi-user.target.wants/* \
 RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y \
  && . $HOME/.cargo/env \
  && cargo install cargo-deb \
- && rustup toolchain install nightly \
- && rustup default nightly
+ && rustup toolchain install stable \
+ && rustup default stable
 
 #USER root
 


### PR DESCRIPTION
**IMPORTANT**: I've switched to `git flow` for this repo.

## How to test

Build an image locally

`./build.sh debian`

Check toolchain version:

`docker run --rm -it docker.stackable.tech/debian-devel-base /root/.cargo/bin/rustup toolchain list`
