### PR TITLE
Feature/add spark operator support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,11 @@ Start the integration tests
 
 # The XXX operator
 
-Currently XXX can only be replaced with `zookeeper`. In the future `spark`, `nifi`, `hdfs`, etc. will be added to the list.
+Supported operator integration tests:
+* zookeeper
+* spark
+
+In the future `nifi`, `hdfs`, etc. will be added to the list.
 
 __NOTE__ This assumes that you have `xxx-operator` and `xxx-oprerator-integration-tests` repositories checkout on your developmnent system. If any of those repositories are missing, this will not work. There are no sanity checks at the moment.
 

--- a/init.sh
+++ b/init.sh
@@ -38,15 +38,12 @@ write_env_file() {
   k3s)
     ;;
   agent)
-    AGENT_SRC_DIR=${PARENT_DIR}/agent
-    AGENT_TESTS_SRC_DIR=${PARENT_DIR}/agent-integration-tests
+    AGENT_SRC_DIR=${PARENT_DIR}/${COMPONENT}
+    AGENT_TESTS_SRC_DIR=${PARENT_DIR}/${COMPONENT}-integration-tests
     ;;
-  spark-operator)
-    OPERATOR_SRC_DIR=${PARENT_DIR}/spark-operator
-    ;;
-  zookeeper-operator)
-    OPERATOR_SRC_DIR=${PARENT_DIR}/zookeeper-operator
-    OPERATOR_TESTS_SRC_DIR=${PARENT_DIR}/zookeeper-operator-integration-tests
+  spark-operator|zookeeper-operator)
+    OPERATOR_SRC_DIR=${PARENT_DIR}/${COMPONENT}
+    OPERATOR_TESTS_SRC_DIR=${PARENT_DIR}/${COMPONENT}-integration-tests
     ;;
    *)
     fatal "Unknown component: ${COMPONENT}. Valid values are: agent, spark-operator, zookeeper-operator"


### PR DESCRIPTION
**IMPORTANT** The `git flow` experiment is over and decided against it for the time being.

This is small change and not the general one that should support all future operator integration tests.

As usual, both the spark-operator and the spark-operator-integration-tests need to be  available on the developer machine.