### PR TITLE
Export k3s file for usage with local (host) kubectl and k9s

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .env
+k3s.yaml
 
 # emacs
 **/#*

--- a/init.sh
+++ b/init.sh
@@ -208,5 +208,6 @@ maybe_install_component_reqs() {
   maybe_label_agent_nodes
   maybe_install_component_reqs
   maybe_install_sidecar
+  prepare_install_kubeconfig
 }
 

--- a/stackable-scripts/functions.sh
+++ b/stackable-scripts/functions.sh
@@ -14,3 +14,9 @@ fatal()
     exit 1
 }
 
+prepare_install_kubeconfig() {
+  local HOSTNAME=$(hostname)
+  docker exec -t k3s cat /etc/rancher/k3s/k3s.yaml | sed "s/k3s:6443/$HOSTNAME:6443/" > k3s.yaml
+  info To use kubectl or k9s from the host system, you need to export KUBECONFIG in this terminal:
+  info export KUBECONFIG=$(pwd)/k3s.yaml
+}


### PR DESCRIPTION
The title says it all. It assumes that the `hostname` is usable on the host system.