### PR TITLE
Bugfix: install Zookeeper in sidecar for NiFi

### DIFF
--- a/centos/docker-compose.yml
+++ b/centos/docker-compose.yml
@@ -38,6 +38,7 @@ services:
       - target: 8428
       - target: 9090
       - target: 9404
+      - target: 10000
 
   operator:
     privileged: true

--- a/debian/docker-compose.yml
+++ b/debian/docker-compose.yml
@@ -40,6 +40,7 @@ services:
       - target: 8428
       - target: 9090
       - target: 9404
+      - target: 10000
 
   operator:
     privileged: true


### PR DESCRIPTION
When running `./init.sh debian nifi-operator` also deploy a `zookeeper-operator` in a sidecar container and create a simple Zookeeper cluster.