### PR TITLE
Add required cliArgs parameter to monitoring CR

### DIFF
--- a/stackable-scripts/cr/monitoring-cluster.yaml
+++ b/stackable-scripts/cr/monitoring-cluster.yaml
@@ -16,4 +16,5 @@ spec:
           scrapeTimeout: 5s
           evaluationInterval: 10s
           scheme: http
+          cliArgs: []
 


### PR DESCRIPTION
The monitoring operator now requires `cliArgs` to be set in the CR to this needs to be updated too.